### PR TITLE
Added aerial to list of apps available

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A collection of resources for the Apple TV 4 including apps that can be installe
 
 ## Apps
 
+### [Aerial](https://github.com/okofish/aerial)
+A viewer for the Apple TV's Aerial screensavers that lets you choose which screensaver you want to view. It dynamically updates the list of videos from Apple's servers. All videos are streamed on-the-fly, so disk usage is minimal.
 ### [Auntie Player](https://github.com/Auntie-Player/apple-tv)
 A proof of concept Apple TV app to access on demand programmes from the BBC.
 ### [Provenance](https://github.com/jasarien/Provenance)


### PR DESCRIPTION
From the [Aerial repo:](https://github.com/okofish/aerial)

> Aerial is a viewer for the Apple TV's Aerial screensavers that lets you choose which screensaver you want to view. It dynamically updates the list of videos from Apple's servers. All videos are streamed on-the-fly, so disk usage is minimal.
